### PR TITLE
Correction pour faire fonctionner le job

### DIFF
--- a/models/mart/mrt_order_daily_report.sql
+++ b/models/mart/mrt_order_daily_report.sql
@@ -9,6 +9,6 @@ SELECT DATE_TRUNC(order_created_at, DAY) AS reporting_date,
     AVG(total_order_amount) AS average_total_order_amount
 FROM {{ ref('int_sales_database__order') }} AS orders
 LEFT JOIN {{ ref('stg_google_sheets__account_manager_region_mapping') }} as mapping ON orders.user_state = mapping.state
-GROUP BY report_date,
+GROUP BY reporting_date,
     account_manager,
     state

--- a/models/staging/sales_database/stg_sales_database__seller.sql
+++ b/models/staging/sales_database/stg_sales_database__seller.sql
@@ -1,6 +1,6 @@
 select seller_id,
  seller_zip_code,
  seller_city,
- seller_state
+ seller_state,
  3 as column_name
 from {{ source('sales_database', 'seller') }}


### PR DESCRIPTION
Modification du `group by` dans `mrt_order...sql` `report_date` => `reporting_date`
dans `staging/seller.sql`, oublie de la virgule.